### PR TITLE
Use synchronous call to copy stream in GetObject* calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,32 @@ jobs:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: [build, unit-test]
+    if: ${{ ! ( github.event.inputs.nuget ) }}
+    steps:
+      - uses: actions/download-artifact@v2
+        id: download
+
+      - name: List artifacts
+        run: ls -ldR ${{steps.download.outputs.download-path}}/**/*
+
+      - name: Install grp
+        run: dotnet tool install gpr -g
+
+      - uses: actions/setup-dotnet@v1
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          dotnet-version: "6.0.x"
+          source-url: https://nuget.pkg.github.com/Project-MONAI/index.json
+          
+      - name: Publish to GitHub
+        run: gpr push '${{ steps.download.outputs.download-path }}/nuget/*.nupkg' --repository ${{ github.repository }} -k ${{ secrets.GITHUB_TOKEN }}
+        
+  release-nuget:
+    name: Official Release to GitHub Packages
+    runs-on: ubuntu-latest
+    needs: [build, unit-test]
+    if: ${{ github.event.inputs.nuget }}
     steps:
       - uses: actions/download-artifact@v2
         id: download
@@ -296,6 +322,8 @@ jobs:
           repository: ${{ steps.repo.outputs._1 }}
           milestone: ${{ env.MAJORMINORPATCH }}
           name: Release v${{ env.MAJORMINORPATCH }}
+          assets: |
+            ${{ steps.download.outputs.download-path }}/plug-ins/*.zip
 
       - name: Publish release with GitReleaseManager
         if: ${{ contains(github.ref, 'refs/heads/main') }}

--- a/src/Plugins/MinIO/MinIoStorageService.cs
+++ b/src/Plugins/MinIO/MinIoStorageService.cs
@@ -67,11 +67,9 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(objectName, nameof(objectName));
 
-            var stream = new MemoryStream();
-
             var client = _minioClientFactory.GetClient();
-            await GetObjectUsingClient(client, bucketName, objectName, async (s) => await s.CopyToAsync(stream), cancellationToken).ConfigureAwait(false);
-
+            var stream = new MemoryStream();
+            await GetObjectUsingClient(client, bucketName, objectName, (s) => s.CopyTo(stream), cancellationToken).ConfigureAwait(false);
             return stream;
         }
 
@@ -219,12 +217,9 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(objectName, nameof(objectName));
 
-            var stream = new MemoryStream();
-
             var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
-
-            await GetObjectUsingClient(client, bucketName, objectName, async (s) => await s.CopyToAsync(stream), cancellationToken).ConfigureAwait(false);
-
+            var stream = new MemoryStream();
+            await GetObjectUsingClient(client, bucketName, objectName, (s) => s.CopyTo(stream), cancellationToken).ConfigureAwait(false);
             return stream;
         }
 

--- a/src/Plugins/MinIO/MinIoStorageService.cs
+++ b/src/Plugins/MinIO/MinIoStorageService.cs
@@ -70,6 +70,7 @@ namespace Monai.Deploy.Storage.MinIO
             var client = _minioClientFactory.GetClient();
             var stream = new MemoryStream();
             await GetObjectUsingClient(client, bucketName, objectName, (s) => s.CopyTo(stream), cancellationToken).ConfigureAwait(false);
+            stream.Seek(0, SeekOrigin.Begin);
             return stream;
         }
 
@@ -220,6 +221,7 @@ namespace Monai.Deploy.Storage.MinIO
             var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             var stream = new MemoryStream();
             await GetObjectUsingClient(client, bucketName, objectName, (s) => s.CopyTo(stream), cancellationToken).ConfigureAwait(false);
+            stream.Seek(0, SeekOrigin.Begin);
             return stream;
         }
 


### PR DESCRIPTION
Fixes #18 .

### Description

The `GetObjectArgs().WithCallbackStream(...)` takes `Action<Stream>` which would not work if a `Func<Stream, Task>` is pass in. The error only occurs when downloading a large number of files.

We should create an integration test to test each plug-in individually.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
