### PR TITLE
fix for policy allowAllInFolder part

### DIFF
--- a/src/S3Policy/PolicyExtensions.cs
+++ b/src/S3Policy/PolicyExtensions.cs
@@ -139,7 +139,7 @@ namespace Monai.Deploy.Storage.S3Policy
                         Action = new string[] { "s3:*" },
                         Effect = "Allow",
                         Resource = policyRequests
-                            .Select(pr => System.IO.Path.Join(pr.BucketName, pr.FolderName, "*"))
+                            .Select(pr => $"{pr.BucketName}/{pr.FolderName}/*")
                             .Distinct()
                             .ToArray(),
                     },

--- a/src/S3Policy/Tests/Extensions/PolicyExtensionsTest.cs
+++ b/src/S3Policy/Tests/Extensions/PolicyExtensionsTest.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using Monai.Deploy.Storage.S3Policy.Policies;
 using Newtonsoft.Json;
 
 namespace Monai.Deploy.Storage.S3Policy.Tests.Extensions
@@ -98,6 +99,22 @@ namespace Monai.Deploy.Storage.S3Policy.Tests.Extensions
         public void ToPolicy_NullFolder_ThrowsException()
         {
             Assert.Throws<ArgumentNullException>(() => PolicyExtensions.ToPolicy("test-bucket", null));
+        }
+
+        [Fact]
+        public async Task ToPolicy_Should_Set_Correct_Allow_All_Path()
+        {
+            const string bucketName = "test-bucket";
+            const string payloadId = "00000000-1000-0000-0000-000000000000";
+
+            var policys = new PolicyRequest[] { new PolicyRequest(bucketName, payloadId) };
+
+            var policyMade = PolicyExtensions.ToPolicy(policys);
+
+            Assert.EndsWith(
+                $"{bucketName}/{payloadId}/*",
+                policyMade.Statement.First(p => p.Sid == "AllowAllS3ActionsInUserFolder").Resource?.First());
+
         }
 
         #endregion ToPolicy


### PR DESCRIPTION
Signed-off-by: Neil South <neil.south@answerdigital.com>

### Description

Fixes # . the fact that the AllowAllS3ActionsInUserFolder policy needs forward slash's


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x ] New tests added to cover the changes.
- [ x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
