### PR TITLE
Include the directory in the policy

### DIFF
--- a/src/S3Policy/PolicyExtensions.cs
+++ b/src/S3Policy/PolicyExtensions.cs
@@ -77,7 +77,7 @@ namespace Monai.Deploy.Storage.S3Policy
                         Sid = "AllowAllS3ActionsInUserFolder",
                         Action = new string[] { "s3:*" },
                         Effect = "Allow",
-                        Resource = new string[] { $"arn:aws:s3:::{bucketName}/{folderName}/*" },
+                        Resource = new string[] { $"arn:aws:s3:::{bucketName}/{folderName}", $"arn:aws:s3:::{bucketName}/{folderName}/*" },
                     },
                 }
             };
@@ -139,7 +139,7 @@ namespace Monai.Deploy.Storage.S3Policy
                         Action = new string[] { "s3:*" },
                         Effect = "Allow",
                         Resource = policyRequests
-                            .Select(pr => $"{pr.BucketName}/{pr.FolderName}/*")
+                            .SelectMany(pr => new []{ $"{pr.BucketName}/{pr.FolderName}" , $"{pr.BucketName}/{pr.FolderName}/*" } )
                             .Distinct()
                             .ToArray(),
                     },

--- a/src/S3Policy/Tests/Extensions/PolicyExtensionsTest.cs
+++ b/src/S3Policy/Tests/Extensions/PolicyExtensionsTest.cs
@@ -86,7 +86,7 @@ namespace Monai.Deploy.Storage.S3Policy.Tests.Extensions
 
             var policyString = JsonConvert.SerializeObject(policy, Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
-            Assert.Equal("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowUserToSeeBucketListInTheConsole\",\"Action\":[\"s3:ListAllMyBuckets\",\"s3:GetBucketLocation\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::*\"]},{\"Sid\":\"AllowRootAndHomeListingOfBucket\",\"Action\":[\"s3:ListBucket\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::test-bucket\"],\"Condition\":{\"StringEquals\":{\"s3:prefix\":[\"Jack/Is/The/Best\",\"Jack/Is/The/\",\"Jack/Is/\",\"Jack/\",\"\"],\"s3:delimiter\":[\"/\"]}}},{\"Sid\":\"AllowListingOfUserFolder\",\"Action\":[\"s3:ListBucket\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::test-bucket\"],\"Condition\":{\"StringEquals\":{\"s3:prefix\":[\"Jack/Is/The/Best/*\"]}}},{\"Sid\":\"AllowAllS3ActionsInUserFolder\",\"Action\":[\"s3:*\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::test-bucket/Jack/Is/The/Best/*\"]}]}", policyString);
+            Assert.Equal("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowUserToSeeBucketListInTheConsole\",\"Action\":[\"s3:ListAllMyBuckets\",\"s3:GetBucketLocation\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::*\"]},{\"Sid\":\"AllowRootAndHomeListingOfBucket\",\"Action\":[\"s3:ListBucket\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::test-bucket\"],\"Condition\":{\"StringEquals\":{\"s3:prefix\":[\"Jack/Is/The/Best\",\"Jack/Is/The/\",\"Jack/Is/\",\"Jack/\",\"\"],\"s3:delimiter\":[\"/\"]}}},{\"Sid\":\"AllowListingOfUserFolder\",\"Action\":[\"s3:ListBucket\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::test-bucket\"],\"Condition\":{\"StringEquals\":{\"s3:prefix\":[\"Jack/Is/The/Best/*\"]}}},{\"Sid\":\"AllowAllS3ActionsInUserFolder\",\"Action\":[\"s3:*\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:s3:::test-bucket/Jack/Is/The/Best\",\"arn:aws:s3:::test-bucket/Jack/Is/The/Best/*\"]}]}", policyString);
         }
 
         [Fact]
@@ -111,9 +111,10 @@ namespace Monai.Deploy.Storage.S3Policy.Tests.Extensions
 
             var policyMade = PolicyExtensions.ToPolicy(policys);
 
-            Assert.EndsWith(
-                $"{bucketName}/{payloadId}/*",
-                policyMade.Statement.First(p => p.Sid == "AllowAllS3ActionsInUserFolder").Resource?.First());
+
+            Assert.Collection(policyMade.Statement.First(p => p.Sid == "AllowAllS3ActionsInUserFolder").Resource!,
+                (item) => item.Equals($"{bucketName}/{payloadId}"),
+                (item) => item.Equals($"{bucketName}/{payloadId}/*"));
 
         }
 


### PR DESCRIPTION
### Description
Fix #41 

For Argo to access the minio path in the bucket, the directory (in addition to `dir-name/*`) must be included in the policy.

A few sentences describing the changes proposed in this pull request.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
