### PR TITLE
MinIO: A new hosted service to create buckets on startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
     - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: "6.0.x"
-
+        
+    - name: Enable Homebrew
+      run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+      
     - name: Install License Finder tool with Homebrew
       uses: tecoli-com/actions-use-homebrew-tools@v0
       with:

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -4,7 +4,7 @@
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
-    - 3.7.13.8
+    - 3.7.100.1
     :when: 2022-08-29 18:11:12.923214877 Z
 - - :approve
   - AWSSDK.S3
@@ -67,7 +67,7 @@
   - :who: mocsharp
     :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
     :versions:
-    - 17.3.1
+    - 17.3.2
     :when: 2022-08-16 18:11:17.245887971 Z
 - - :approve
   - Microsoft.Extensions.Configuration
@@ -144,14 +144,14 @@
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
     :versions:
-    - 6.0.9
+    - 6.0.10
     :when: 2022-08-29 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
     :versions:
-    - 6.0.9
+    - 6.0.10
     :when: 2022-08-29 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.FileProviders.Abstractions
@@ -298,14 +298,14 @@
   - :who: mocsharp
     :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
     :versions:
-    - 17.3.1
+    - 17.3.2
     :when: 2022-08-16 18:11:32.293966383 Z
 - - :approve
   - Microsoft.TestPlatform.TestHost
   - :who: mocsharp
     :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
     :versions:
-    - 17.3.1
+    - 17.3.2
     :when: 2022-08-16 18:11:33.162650175 Z
 - - :approve
   - Microsoft.Win32.Primitives

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -11,14 +11,14 @@
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
-    - 3.7.9.57
+    - 3.7.101.1
     :when: 2022-08-29 18:11:13.354973002 Z
 - - :approve
   - AWSSDK.SecurityToken
   - :who: mocsharp
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
-    - 3.7.1.203
+    - 3.7.100.1
     :when: 2022-08-16 18:11:13.781079769 Z
 - - :approve
   - Ardalis.GuardClauses
@@ -263,7 +263,7 @@
   - :who: mocsharp
     :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
     :versions:
-    - 17.3.1
+    - 17.3.2
     :when: 2022-08-16 18:11:29.155295778 Z
 - - :approve
   - Microsoft.NETCore.Platforms

--- a/src/Plugins/AWSS3/Monai.Deploy.Storage.AWSS3.csproj
+++ b/src/Plugins/AWSS3/Monai.Deploy.Storage.AWSS3.csproj
@@ -49,8 +49,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.57" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.203" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.101.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Plugins/MinIO/ConfigurationKeys.cs
+++ b/src/Plugins/MinIO/ConfigurationKeys.cs
@@ -28,6 +28,7 @@ namespace Monai.Deploy.Storage.MinIO
         public static readonly string CredentialServiceUrl = "credentialServiceUrl";
         public static readonly string McExecutablePath = "executableLocation";
         public static readonly string McServiceName = "serviceName";
+        public static readonly string CreateBucket = "createBuckets";
 
         public static readonly string[] RequiredKeys = new[] { EndPoint, AccessKey, AccessToken, SecuredConnection, Region };
         public static readonly string[] McRequiredKeys = new[] { EndPoint, AccessKey, AccessToken, McExecutablePath, McServiceName };

--- a/src/Plugins/MinIO/ConfigurationKeys.cs
+++ b/src/Plugins/MinIO/ConfigurationKeys.cs
@@ -28,7 +28,7 @@ namespace Monai.Deploy.Storage.MinIO
         public static readonly string CredentialServiceUrl = "credentialServiceUrl";
         public static readonly string McExecutablePath = "executableLocation";
         public static readonly string McServiceName = "serviceName";
-        public static readonly string CreateBucket = "createBuckets";
+        public static readonly string CreateBuckets = "createBuckets";
 
         public static readonly string[] RequiredKeys = new[] { EndPoint, AccessKey, AccessToken, SecuredConnection, Region };
         public static readonly string[] McRequiredKeys = new[] { EndPoint, AccessKey, AccessToken, McExecutablePath, McServiceName };

--- a/src/Plugins/MinIO/IMinIoClientFactory.cs
+++ b/src/Plugins/MinIO/IMinIoClientFactory.cs
@@ -21,10 +21,22 @@ namespace Monai.Deploy.Storage.MinIO
 {
     public interface IMinIoClientFactory
     {
-        MinioClient GetClient();
+        IMinioClient GetClient();
 
-        MinioClient GetClient(Credentials credentials);
+        IMinioClient GetClient(Credentials credentials);
 
-        MinioClient GetClient(Credentials credentials, string region);
+        IMinioClient GetClient(Credentials credentials, string region);
+
+        IObjectOperations GetObjectOperationsClient();
+
+        IObjectOperations GetObjectOperationsClient(Credentials credentials);
+
+        IObjectOperations GetObjectOperationsClient(Credentials credentials, string region);
+
+        IBucketOperations GetBucketOperationsClient();
+
+        IBucketOperations GetBucketOperationsClient(Credentials credentials);
+
+        IBucketOperations GetBucketOperationsClient(Credentials credentials, string region);
     }
 }

--- a/src/Plugins/MinIO/LoggerMethods.cs
+++ b/src/Plugins/MinIO/LoggerMethods.cs
@@ -34,5 +34,14 @@ namespace Monai.Deploy.Storage.MinIO
 
         [LoggerMessage(EventId = 20004, Level = LogLevel.Debug, Message = "Temporary credential policy={policy}.")]
         public static partial void TemporaryCredentialPolicy(this ILogger logger, string policy);
+
+        [LoggerMessage(EventId = 20005, Level = LogLevel.Information, Message = "`createBuckets` not configured; no buckets created.")]
+        public static partial void NoBucketCreated(this ILogger logger);
+
+        [LoggerMessage(EventId = 20006, Level = LogLevel.Critical, Message = "Error creating bucket {bucket} in region {region}.")]
+        public static partial void ErrorCreatingBucket(this ILogger logger, string bucket, string region, Exception ex);
+
+        [LoggerMessage(EventId = 20007, Level = LogLevel.Information, Message = "Bucket {bucket} created in region {region}.")]
+        public static partial void BucketCreated(this ILogger logger, string bucket, string region);
     }
 }

--- a/src/Plugins/MinIO/MinIoHealthCheck.cs
+++ b/src/Plugins/MinIO/MinIoHealthCheck.cs
@@ -34,7 +34,7 @@ namespace Monai.Deploy.Storage.MinIO
         {
             try
             {
-                var minioClient = _minIoClientFactory.GetClient();
+                var minioClient = _minIoClientFactory.GetBucketOperationsClient();
                 await minioClient.ListBucketsAsync(cancellationToken).ConfigureAwait(false);
 
                 return HealthCheckResult.Healthy();

--- a/src/Plugins/MinIO/MinIoStartup.cs
+++ b/src/Plugins/MinIO/MinIoStartup.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Monai.Deploy.Storage.Configuration;
+
+namespace Monai.Deploy.Storage.MinIO
+{
+    public class MinIoStartup : IHostedService
+    {
+        private readonly IMinIoClientFactory _minIoClientFactory;
+        private readonly IOptions<StorageServiceConfiguration> _options;
+        private readonly ILogger<MinIoStartup> _logger;
+
+        public MinIoStartup(
+            IMinIoClientFactory minIoClientFactory,
+            IOptions<StorageServiceConfiguration> options,
+            ILogger<MinIoStartup> logger)
+        {
+            _minIoClientFactory = minIoClientFactory ?? throw new ArgumentNullException(nameof(minIoClientFactory));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_options.Value.Settings.ContainsKey(ConfigurationKeys.CreateBucket))
+            {
+                var buckets = _options.Value.Settings[ConfigurationKeys.CreateBucket];
+                var region = _options.Value.Settings[ConfigurationKeys.Region];
+
+                if (!string.IsNullOrWhiteSpace(buckets))
+                {
+                    var exceptions = new List<Exception>();
+                    var bucketNames = buckets.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+                    var client = _minIoClientFactory.GetClient();
+
+                    foreach (var bucket in bucketNames)
+                    {
+                        try
+                        {
+                            await CreateBucket(client, bucket, region, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.ErrorCreatingBucket(bucket, region, ex);
+                            exceptions.Add(ex);
+                        }
+                    }
+
+                    if (exceptions.Any())
+                    {
+                        throw new AggregateException("Error creating buckets.", exceptions);
+                    }
+                }
+            }
+            else
+            {
+                _logger.NoBucketCreated();
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        private async Task CreateBucket(MinioClient client, string bucket, string region, CancellationToken cancellationToken)
+        {
+            Guard.Against.Null(client, nameof(client));
+            Guard.Against.Null(bucket, nameof(bucket));
+
+            var bucketExistsArgs = new BucketExistsArgs().WithBucket(bucket);
+            if (!await client.BucketExistsAsync(bucketExistsArgs, cancellationToken).ConfigureAwait(false))
+            {
+                var makeBucketArgs = new MakeBucketArgs().WithBucket(bucket);
+                if (!string.IsNullOrWhiteSpace(region))
+                {
+                    makeBucketArgs.WithLocation(region);
+                }
+                await client.MakeBucketAsync(makeBucketArgs, cancellationToken).ConfigureAwait(false);
+                _logger.BucketCreated(bucket, region);
+            }
+        }
+    }
+}

--- a/src/Plugins/MinIO/MinIoStartup.cs
+++ b/src/Plugins/MinIO/MinIoStartup.cs
@@ -41,17 +41,17 @@ namespace Monai.Deploy.Storage.MinIO
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (_options.Value.Settings.ContainsKey(ConfigurationKeys.CreateBucket))
+            if (_options.Value.Settings.ContainsKey(ConfigurationKeys.CreateBuckets))
             {
-                var buckets = _options.Value.Settings[ConfigurationKeys.CreateBucket];
-                var region = _options.Value.Settings[ConfigurationKeys.Region];
+                var buckets = _options.Value.Settings[ConfigurationKeys.CreateBuckets];
+                var region = _options.Value.Settings.ContainsKey(ConfigurationKeys.Region) ? _options.Value.Settings[ConfigurationKeys.Region] : string.Empty;
 
                 if (!string.IsNullOrWhiteSpace(buckets))
                 {
                     var exceptions = new List<Exception>();
                     var bucketNames = buckets.Split(',', StringSplitOptions.RemoveEmptyEntries);
 
-                    var client = _minIoClientFactory.GetClient();
+                    var client = _minIoClientFactory.GetBucketOperationsClient();
 
                     foreach (var bucket in bucketNames)
                     {
@@ -83,7 +83,7 @@ namespace Monai.Deploy.Storage.MinIO
             return Task.CompletedTask;
         }
 
-        private async Task CreateBucket(MinioClient client, string bucket, string region, CancellationToken cancellationToken)
+        private async Task CreateBucket(IBucketOperations client, string bucket, string region, CancellationToken cancellationToken)
         {
             Guard.Against.Null(client, nameof(client));
             Guard.Against.Null(bucket, nameof(bucket));

--- a/src/Plugins/MinIO/MinIoStartup.cs
+++ b/src/Plugins/MinIO/MinIoStartup.cs
@@ -57,7 +57,7 @@ namespace Monai.Deploy.Storage.MinIO
                     {
                         try
                         {
-                            await CreateBucket(client, bucket, region, cancellationToken).ConfigureAwait(false);
+                            await CreateBucket(client, bucket.Trim(), region, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception ex)
                         {

--- a/src/Plugins/MinIO/MinIoStorageService.cs
+++ b/src/Plugins/MinIO/MinIoStorageService.cs
@@ -39,7 +39,7 @@ namespace Monai.Deploy.Storage.MinIO
         public MinIoStorageService(IMinIoClientFactory minioClientFactory, IAmazonSecurityTokenServiceClientFactory amazonSecurityTokenServiceClientFactory, IOptions<StorageServiceConfiguration> options, ILogger<MinIoStorageService> logger)
         {
             Guard.Against.Null(options, nameof(options));
-            _minioClientFactory = minioClientFactory ?? throw new ArgumentNullException(nameof(minioClientFactory));
+            _minioClientFactory = minioClientFactory ?? throw new ArgumentNullException(nameof(IMinIoClientFactory));
             _amazonSecurityTokenServiceClientFactory = amazonSecurityTokenServiceClientFactory ?? throw new ArgumentNullException(nameof(amazonSecurityTokenServiceClientFactory));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -71,7 +71,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(destinationBucketName, nameof(destinationBucketName));
             Guard.Against.NullOrWhiteSpace(destinationObjectName, nameof(destinationObjectName));
 
-            var client = _minioClientFactory.GetClient();
+            var client = _minioClientFactory.GetObjectOperationsClient();
             await CopyObjectUsingClient(client, sourceBucketName, sourceObjectName, destinationBucketName, destinationObjectName, cancellationToken).ConfigureAwait(false);
         }
 
@@ -80,7 +80,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(objectName, nameof(objectName));
 
-            var client = _minioClientFactory.GetClient();
+            var client = _minioClientFactory.GetObjectOperationsClient();
             var stream = new MemoryStream();
             await GetObjectUsingClient(client, bucketName, objectName, (s) => s.CopyTo(stream), cancellationToken).ConfigureAwait(false);
             stream.Seek(0, SeekOrigin.Begin);
@@ -91,7 +91,7 @@ namespace Monai.Deploy.Storage.MinIO
         {
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
 
-            var client = _minioClientFactory.GetClient();
+            var client = _minioClientFactory.GetBucketOperationsClient();
             return await ListObjectsUsingClient(client, bucketName, prefix, recursive, cancellationToken).ConfigureAwait(false);
         }
 
@@ -154,7 +154,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.Null(data, nameof(data));
             Guard.Against.NullOrWhiteSpace(contentType, nameof(contentType));
 
-            var client = _minioClientFactory.GetClient();
+            var client = _minioClientFactory.GetObjectOperationsClient();
             await PutObjectUsingClient(client, bucketName, objectName, data, size, contentType, metadata, cancellationToken).ConfigureAwait(false);
         }
 
@@ -163,7 +163,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(objectName, nameof(objectName));
 
-            var client = _minioClientFactory.GetClient();
+            var client = _minioClientFactory.GetObjectOperationsClient();
             await RemoveObjectUsingClient(client, bucketName, objectName, cancellationToken).ConfigureAwait(false);
         }
 
@@ -172,7 +172,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrEmpty(objectNames, nameof(objectNames));
 
-            var client = _minioClientFactory.GetClient();
+            var client = _minioClientFactory.GetObjectOperationsClient();
             await RemoveObjectsUsingClient(client, bucketName, objectNames, cancellationToken).ConfigureAwait(false);
         }
 
@@ -223,7 +223,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(destinationBucketName, nameof(destinationBucketName));
             Guard.Against.NullOrWhiteSpace(destinationObjectName, nameof(destinationObjectName));
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetObjectOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             await CopyObjectUsingClient(client, sourceBucketName, sourceObjectName, destinationBucketName, destinationObjectName, cancellationToken).ConfigureAwait(false);
         }
 
@@ -232,7 +232,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(objectName, nameof(objectName));
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetObjectOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             var stream = new MemoryStream();
             await GetObjectUsingClient(client, bucketName, objectName, (s) => s.CopyTo(stream), cancellationToken).ConfigureAwait(false);
             stream.Seek(0, SeekOrigin.Begin);
@@ -243,7 +243,7 @@ namespace Monai.Deploy.Storage.MinIO
         {
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetBucketOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             return await ListObjectsUsingClient(client, bucketName, prefix, recursive, cancellationToken).ConfigureAwait(false);
         }
 
@@ -254,7 +254,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.Null(data, nameof(data));
             Guard.Against.NullOrWhiteSpace(contentType, nameof(contentType));
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetObjectOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             await PutObjectUsingClient(client, bucketName, objectName, data, size, contentType, metadata, cancellationToken).ConfigureAwait(false);
         }
 
@@ -263,7 +263,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrWhiteSpace(objectName, nameof(objectName));
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetObjectOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             await RemoveObjectUsingClient(client, bucketName, objectName, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -272,7 +272,7 @@ namespace Monai.Deploy.Storage.MinIO
             Guard.Against.NullOrWhiteSpace(bucketName, nameof(bucketName));
             Guard.Against.NullOrEmpty(objectNames, nameof(objectNames));
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetObjectOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             await RemoveObjectsUsingClient(client, bucketName, objectNames, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -287,7 +287,7 @@ namespace Monai.Deploy.Storage.MinIO
             var length = data.Length;
             var stream = new MemoryStream(data);
 
-            var client = _minioClientFactory.GetClient(credentials, _options.Settings[ConfigurationKeys.Region]);
+            var client = _minioClientFactory.GetObjectOperationsClient(credentials, _options.Settings[ConfigurationKeys.Region]);
             await PutObjectUsingClient(client, bucketName, stubFile, stream, length, "application/octet-stream", null, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -295,7 +295,7 @@ namespace Monai.Deploy.Storage.MinIO
 
         #region Internal Helper Methods
 
-        private static async Task CopyObjectUsingClient(MinioClient client, string sourceBucketName, string sourceObjectName, string destinationBucketName, string destinationObjectName, CancellationToken cancellationToken)
+        private static async Task CopyObjectUsingClient(IObjectOperations client, string sourceBucketName, string sourceObjectName, string destinationBucketName, string destinationObjectName, CancellationToken cancellationToken)
         {
             var copySourceObjectArgs = new CopySourceObjectArgs()
                            .WithBucket(sourceBucketName)
@@ -307,7 +307,7 @@ namespace Monai.Deploy.Storage.MinIO
             await client.CopyObjectAsync(copyObjectArgs, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task GetObjectUsingClient(MinioClient client, string bucketName, string objectName, Action<Stream> callback, CancellationToken cancellationToken)
+        private static async Task GetObjectUsingClient(IObjectOperations client, string bucketName, string objectName, Action<Stream> callback, CancellationToken cancellationToken)
         {
             var args = new GetObjectArgs()
                             .WithBucket(bucketName)
@@ -316,7 +316,7 @@ namespace Monai.Deploy.Storage.MinIO
             await client.GetObjectAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<IList<VirtualFileInfo>> ListObjectsUsingClient(MinioClient client, string bucketName, string? prefix, bool recursive, CancellationToken cancellationToken)
+        private async Task<IList<VirtualFileInfo>> ListObjectsUsingClient(IBucketOperations client, string bucketName, string? prefix, bool recursive, CancellationToken cancellationToken)
         {
             return await Task.Run(() =>
             {
@@ -349,7 +349,7 @@ namespace Monai.Deploy.Storage.MinIO
             }).ConfigureAwait(false);
         }
 
-        private static async Task RemoveObjectUsingClient(MinioClient client, string bucketName, string objectName, CancellationToken cancellationToken)
+        private static async Task RemoveObjectUsingClient(IObjectOperations client, string bucketName, string objectName, CancellationToken cancellationToken)
         {
             var args = new RemoveObjectArgs()
                            .WithBucket(bucketName)
@@ -357,7 +357,7 @@ namespace Monai.Deploy.Storage.MinIO
             await client.RemoveObjectAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task PutObjectUsingClient(MinioClient client, string bucketName, string objectName, Stream data, long size, string contentType, Dictionary<string, string>? metadata, CancellationToken cancellationToken)
+        private static async Task PutObjectUsingClient(IObjectOperations client, string bucketName, string objectName, Stream data, long size, string contentType, Dictionary<string, string>? metadata, CancellationToken cancellationToken)
         {
             var args = new PutObjectArgs()
                                 .WithBucket(bucketName)
@@ -373,7 +373,7 @@ namespace Monai.Deploy.Storage.MinIO
             await client.PutObjectAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task RemoveObjectsUsingClient(MinioClient client, string bucketName, IEnumerable<string> objectNames, CancellationToken cancellationToken)
+        private static async Task RemoveObjectsUsingClient(IObjectOperations client, string bucketName, IEnumerable<string> objectNames, CancellationToken cancellationToken)
         {
             var args = new RemoveObjectsArgs()
                            .WithBucket(bucketName)

--- a/src/Plugins/MinIO/Monai.Deploy.Storage.MinIO.csproj
+++ b/src/Plugins/MinIO/Monai.Deploy.Storage.MinIO.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,7 @@
   
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.203" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Minio" Version="4.0.5" />

--- a/src/Plugins/MinIO/ServiceRegistration.cs
+++ b/src/Plugins/MinIO/ServiceRegistration.cs
@@ -27,6 +27,9 @@ namespace Monai.Deploy.Storage.MinIO
             services.AddSingleton<IAmazonSecurityTokenServiceClientFactory, AmazonSecurityTokenServiceClientFactory>();
             services.AddSingleton<IStorageService, MinIoStorageService>();
             services.AddSingleton<IStorageAdminService, StorageAdminService>();
+            services.AddSingleton<MinIoStartup>();
+
+            services.AddHostedService(p => p.GetRequiredService<MinIoStartup>());
             return services;
         }
     }

--- a/src/Plugins/MinIO/Tests/MinIoHealthCheckTest.cs
+++ b/src/Plugins/MinIO/Tests/MinIoHealthCheckTest.cs
@@ -36,7 +36,7 @@ namespace Monai.Deploy.Storage.MinIO.Tests
         [Fact]
         public async Task CheckHealthAsync_WhenFailedToListBucket_ReturnUnhealthy()
         {
-            _minIoClientFactory.Setup(p => p.GetClient()).Throws(new Exception("error"));
+            _minIoClientFactory.Setup(p => p.GetBucketOperationsClient()).Throws(new Exception("error"));
 
             var healthCheck = new MinIoHealthCheck(_minIoClientFactory.Object, _logger.Object);
             var results = await healthCheck.CheckHealthAsync(new HealthCheckContext()).ConfigureAwait(false);
@@ -54,7 +54,7 @@ namespace Monai.Deploy.Storage.MinIO.Tests
             .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
 
-            _minIoClientFactory.Setup(p => p.GetClient()).Returns(minioClient);
+            _minIoClientFactory.Setup(p => p.GetBucketOperationsClient()).Returns(minioClient);
             var healthCheck = new MinIoHealthCheck(_minIoClientFactory.Object, _logger.Object);
             var results = await healthCheck.CheckHealthAsync(new HealthCheckContext()).ConfigureAwait(false);
 

--- a/src/Plugins/MinIO/Tests/MinIoStartupTest.cs
+++ b/src/Plugins/MinIO/Tests/MinIoStartupTest.cs
@@ -1,0 +1,154 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Monai.Deploy.Storage.Configuration;
+using Moq;
+using Xunit;
+
+namespace Monai.Deploy.Storage.MinIO.Tests
+{
+    public class MinIoStartupTest
+    {
+        private readonly Mock<IMinIoClientFactory> _minIoClientFactory;
+        private readonly IOptions<StorageServiceConfiguration> _options;
+        private readonly Mock<ILogger<MinIoStartup>> _logger;
+        private readonly Mock<IBucketOperations> _minio;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        public MinIoStartupTest()
+        {
+            _minIoClientFactory = new Mock<IMinIoClientFactory>();
+            _options = Options.Create(new StorageServiceConfiguration());
+            _logger = new Mock<ILogger<MinIoStartup>>();
+            _minio = new Mock<IBucketOperations>();
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            _minIoClientFactory.Setup(p => p.GetBucketOperationsClient()).Returns(_minio.Object);
+            _options.Value.Settings[ConfigurationKeys.EndPoint] = "localhost";
+            _options.Value.Settings[ConfigurationKeys.AccessKey] = "key";
+            _options.Value.Settings[ConfigurationKeys.AccessToken] = "token";
+            _options.Value.Settings[ConfigurationKeys.Region] = "region";
+        }
+
+        [Fact]
+        public void GivenNoCreateBucketKey_WhenStartupIsCalled_ItShallNotCreateBuckets()
+        {
+            var service = new MinIoStartup(_minIoClientFactory.Object, _options, _logger.Object);
+
+            var task = service.StartAsync(_cancellationTokenSource.Token);
+
+            Assert.True(task.IsCompletedSuccessfully);
+            _minIoClientFactory.Verify(p => p.GetBucketOperationsClient(), Times.Never());
+        }
+
+        [Fact]
+        public void GivenCreateBucketKeyWithNoValue_WhenStartupIsCalled_ItShallNotCreateBuckets()
+        {
+            _options.Value.Settings[ConfigurationKeys.CreateBuckets] = string.Empty;
+            var service = new MinIoStartup(_minIoClientFactory.Object, _options, _logger.Object);
+
+            var task = service.StartAsync(_cancellationTokenSource.Token);
+
+            Assert.True(task.IsCompletedSuccessfully);
+            _minIoClientFactory.Verify(p => p.GetBucketOperationsClient(), Times.Never());
+        }
+
+        [Fact]
+        public async Task GivenCreateBucketKeyValues_WhenStartupIsCalled_ItShallThrowExceptionWhenUnableToCheckBucketsExistence()
+        {
+            var bucket = "mybucket";
+            _options.Value.Settings[ConfigurationKeys.CreateBuckets] = bucket;
+            _minio.Setup(p => p.BucketExistsAsync(It.IsAny<BucketExistsArgs>(), It.IsAny<CancellationToken>())).Throws(new Exception("error"));
+
+            var service = new MinIoStartup(_minIoClientFactory.Object, _options, _logger.Object);
+
+            var task = service.StartAsync(_cancellationTokenSource.Token);
+            var exception = await Assert.ThrowsAsync<AggregateException>(async () =>
+            {
+                await task;
+            });
+
+            Assert.NotNull(exception);
+            Assert.True(task.IsFaulted);
+            _minIoClientFactory.Verify(p => p.GetBucketOperationsClient(), Times.Once());
+            _minio.Verify(p => p.BucketExistsAsync(It.IsAny<BucketExistsArgs>(), It.IsAny<CancellationToken>()), Times.Once());
+            _minio.Verify(p => p.MakeBucketAsync(It.IsAny<MakeBucketArgs>(), It.IsAny<CancellationToken>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task GivenCreateBucketKeyValues_WhenStartupIsCalled_ItShallThrowExceptionWhenUnableToCreateBuckets()
+        {
+            var bucket = "my-bucket,your-bucket";
+            _options.Value.Settings[ConfigurationKeys.CreateBuckets] = bucket;
+            _minio.Setup(p => p.MakeBucketAsync(It.IsAny<MakeBucketArgs>(), It.IsAny<CancellationToken>())).Throws(new Exception("error"));
+
+            var service = new MinIoStartup(_minIoClientFactory.Object, _options, _logger.Object);
+
+            var task = service.StartAsync(_cancellationTokenSource.Token);
+            var exceptions = await Assert.ThrowsAsync<AggregateException>(async () =>
+            {
+                await task;
+            });
+
+            Assert.Equal(2, exceptions.InnerExceptions.Count);
+            Assert.True(task.IsFaulted);
+            _minIoClientFactory.Verify(p => p.GetBucketOperationsClient(), Times.Once());
+            _minio.Verify(p => p.BucketExistsAsync(It.IsAny<BucketExistsArgs>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _minio.Verify(p => p.MakeBucketAsync(It.IsAny<MakeBucketArgs>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData("bucket1", 1)]
+        [InlineData("bucket1,bucket2", 2)]
+        [InlineData("bucket1,bucket2,,bucket3", 3)]
+        public async Task GivenCreateBucketKeyValues_WhenStartupIsCalled_ItShallCreeateBuckets(string buckets, int count)
+        {
+            _options.Value.Settings[ConfigurationKeys.CreateBuckets] = buckets;
+            var service = new MinIoStartup(_minIoClientFactory.Object, _options, _logger.Object);
+
+            var task = service.StartAsync(_cancellationTokenSource.Token);
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            _minIoClientFactory.Verify(p => p.GetBucketOperationsClient(), Times.Once());
+            _minio.Verify(p => p.BucketExistsAsync(It.IsAny<BucketExistsArgs>(), It.IsAny<CancellationToken>()), Times.Exactly(count));
+            _minio.Verify(p => p.MakeBucketAsync(It.IsAny<MakeBucketArgs>(), It.IsAny<CancellationToken>()), Times.Exactly(count));
+        }
+
+        [Theory]
+        [InlineData("bucket1", 1)]
+        [InlineData("bucket1,bucket2", 2)]
+        [InlineData("bucket1,bucket2,,bucket3", 3)]
+        public async Task GivenCreateBucketKeyValuesWithoutRegion_WhenStartupIsCalled_ItShallCreeateBuckets(string buckets, int count)
+        {
+            _options.Value.Settings[ConfigurationKeys.CreateBuckets] = buckets;
+            _options.Value.Settings.Remove(ConfigurationKeys.Region);
+
+            var service = new MinIoStartup(_minIoClientFactory.Object, _options, _logger.Object);
+
+            var task = service.StartAsync(_cancellationTokenSource.Token);
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            _minIoClientFactory.Verify(p => p.GetBucketOperationsClient(), Times.Once());
+            _minio.Verify(p => p.BucketExistsAsync(It.IsAny<BucketExistsArgs>(), It.IsAny<CancellationToken>()), Times.Exactly(count));
+            _minio.Verify(p => p.MakeBucketAsync(It.IsAny<MakeBucketArgs>(), It.IsAny<CancellationToken>()), Times.Exactly(count));
+        }
+    }
+}

--- a/src/Plugins/MinIO/Tests/Monai.Deploy.Storage.MinIO.Tests.csproj
+++ b/src/Plugins/MinIO/Tests/Monai.Deploy.Storage.MinIO.Tests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Plugins/MinIO/Tests/ServiceRegistrationTest.cs
+++ b/src/Plugins/MinIO/Tests/ServiceRegistrationTest.cs
@@ -51,7 +51,7 @@ namespace Monai.Deploy.Storage.MinIO.Tests
 
             Assert.Same(serviceCollection.Object, returnedServiceCollection);
 
-            serviceCollection.Verify(p => p.Add(It.IsAny<ServiceDescriptor>()), Times.Exactly(4));
+            serviceCollection.Verify(p => p.Add(It.IsAny<ServiceDescriptor>()), Times.Exactly(6));
         }
 
         [Fact]

--- a/src/S3Policy/Tests/Monai.Deploy.Storage.S3Policy.Tests.csproj
+++ b/src/S3Policy/Tests/Monai.Deploy.Storage.S3Policy.Tests.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Storage/Monai.Deploy.Storage.csproj
+++ b/src/Storage/Monai.Deploy.Storage.csproj
@@ -62,9 +62,9 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.203" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.100.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
   </ItemGroup>

--- a/src/Storage/Tests/Monai.Deploy.Storage.Tests.csproj
+++ b/src/Storage/Tests/Monai.Deploy.Storage.Tests.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/third-party-licenses.md
+++ b/third-party-licenses.md
@@ -44,15 +44,15 @@ SOFTWARE.
 
 
 <details>
-<summary>AWSSDK.Core 3.7.13.8</summary>
+<summary>AWSSDK.Core 3.7.100.1</summary>
 
 ## AWSSDK.Core
 
-- Version: 3.7.13.8
+- Version: 3.7.100.1
 - Authors: Amazon Web Services
 - Owners: Amazon Web Services
 - Project URL: https://github.com/aws/aws-sdk-net/
-- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.Core/3.7.13.8)
+- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.Core/3.7.100.1)
 - License: [Apache-2.0](https://github.com/aws/aws-sdk-net/raw/master/License.txt)
 
 
@@ -497,16 +497,16 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.CodeCoverage 17.3.1</summary>
+<summary>Microsoft.CodeCoverage 17.3.2</summary>
 
 ## Microsoft.CodeCoverage
 
-- Version: 17.3.1
+- Version: 17.3.2
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.CodeCoverage/17.3.1)
-- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.CodeCoverage/17.3.2)
+- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.2/LICENSE)
 
 
 ```
@@ -945,14 +945,14 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.Extensions.Diagnostics.HealthChecks 6.0.9</summary>
+<summary>Microsoft.Extensions.Diagnostics.HealthChecks 6.0.10</summary>
 
 ## Microsoft.Extensions.Diagnostics.HealthChecks
 
-- Version: 6.0.9
+- Version: 6.0.10
 - Authors: Microsoft
 - Project URL: https://asp.net/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks/6.0.9)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks/6.0.10)
 - License: [MIT](https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
 
 
@@ -986,7 +986,7 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions 6.0.9</summary>
+<summary>Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions 6.0.10</summary>
 
 ## Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions
 
@@ -2480,15 +2480,15 @@ consequential or other damages.
 
 
 <details>
-<summary>Microsoft.TestPlatform.ObjectModel 17.3.1</summary>
+<summary>Microsoft.TestPlatform.ObjectModel 17.3.2</summary>
 
 ## Microsoft.TestPlatform.ObjectModel
 
-- Version: 17.3.1
+- Version: 17.3.2
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/17.3.1)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/17.3.2)
 - License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
 
 
@@ -2518,15 +2518,15 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.TestPlatform.TestHost 17.3.1</summary>
+<summary>Microsoft.TestPlatform.TestHost 17.3.2</summary>
 
 ## Microsoft.TestPlatform.TestHost
 
-- Version: 17.3.1
+- Version: 17.3.2
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.TestHost/17.3.1)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.TestHost/17.3.2)
 - License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
 
 

--- a/third-party-licenses.md
+++ b/third-party-licenses.md
@@ -117,15 +117,15 @@ END OF TERMS AND CONDITIONS
 
 
 <details>
-<summary>AWSSDK.S3 3.7.9.57</summary>
+<summary>AWSSDK.S3 3.7.101.1</summary>
 
 ## AWSSDK.S3
 
-- Version: 3.7.9.57
+- Version: 3.7.101.1
 - Authors: Amazon Web Services
 - Owners: Amazon Web Services
 - Project URL: https://github.com/aws/aws-sdk-net/
-- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.S3/3.7.9.57)
+- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.S3/3.7.101.1)
 - License: [Apache-2.0](https://github.com/aws/aws-sdk-net/raw/master/License.txt)
 
 
@@ -190,15 +190,15 @@ END OF TERMS AND CONDITIONS
 
 
 <details>
-<summary>AWSSDK.SecurityToken 3.7.1.203</summary>
+<summary>AWSSDK.SecurityToken 3.7.100.1</summary>
 
 ## AWSSDK.SecurityToken
 
-- Version: 3.7.1.203
+- Version: 3.7.100.1
 - Authors: Amazon Web Services
 - Owners: Amazon Web Services
 - Project URL: https://github.com/aws/aws-sdk-net/
-- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.SecurityToken/3.7.1.203)
+- Source: [NuGet](https://www.nuget.org/packages/AWSSDK.SecurityToken/3.7.100.1)
 - License: [Apache-2.0](https://github.com/aws/aws-sdk-net/raw/master/License.txt)
 
 
@@ -1642,15 +1642,15 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.NET.Test.Sdk 17.3.1</summary>
+<summary>Microsoft.NET.Test.Sdk 17.3.2</summary>
 
 ## Microsoft.NET.Test.Sdk
 
-- Version: 17.3.1
+- Version: 17.3.2
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.3.1)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.3.2)
 - License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
 
 


### PR DESCRIPTION
### Description

A new configuration key `createBuckets` that allows users to specify a list of buckets (comma separated) to create on startup.

e.g

```
...
"createBuckets": "my-bucket-1, my-bucket-2, your-bucket-3"
...
```
### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
