### PR TITLE
Remove reference of .NET packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,6 @@ jobs:
       run: dotnet build -c ${{ env.BUILD_CONFIG }} --nologo ${{ env.SOLUTION }}
       working-directory: ./src
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-
   analyze:
     runs-on: ubuntu-latest
     permissions:

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -5,7 +5,7 @@
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
     - 3.7.100.25
-    - 3.7.105.16
+    - 3.7.105.20
     :when: 2022-08-29 18:11:12.923214877 Z
 - - :approve
   - AWSSDK.S3
@@ -13,7 +13,7 @@
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
     - 3.7.101.25
-    - 3.7.103.24
+    - 3.7.103.28
     :when: 2022-08-29 18:11:13.354973002 Z
 - - :approve
   - AWSSDK.SecurityToken
@@ -21,8 +21,7 @@
     :why: Apache-2.0 (https://github.com/aws/aws-sdk-net/raw/master/License.txt)
     :versions:
     - 3.7.100.25
-    - 3.7.101.21
-    - 3.7.101.22
+    - 3.7.101.26
     :when: 2022-08-16 18:11:13.781079769 Z
 - - :approve
   - Ardalis.GuardClauses
@@ -81,7 +80,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.1
-    - 7.0.0
     :when: 2022-08-16 18:11:18.098911237 Z
 - - :approve
   - Microsoft.Extensions.Configuration.Abstractions
@@ -89,7 +87,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:18.530982995 Z
 - - :approve
   - Microsoft.Extensions.Configuration.Binder
@@ -97,7 +94,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.3
     :when: 2022-08-16 18:11:18.988384334 Z
 - - :approve
   - Microsoft.Extensions.Configuration.CommandLine
@@ -105,7 +101,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:19.413255201 Z
 - - :approve
   - Microsoft.Extensions.Configuration.EnvironmentVariables
@@ -113,7 +108,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.1
-    - 7.0.0
     :when: 2022-08-16 18:11:19.867533681 Z
 - - :approve
   - Microsoft.Extensions.Configuration.FileExtensions
@@ -121,7 +115,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:20.301107519 Z
 - - :approve
   - Microsoft.Extensions.Configuration.Json
@@ -129,7 +122,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:20.734464747 Z
 - - :approve
   - Microsoft.Extensions.Configuration.UserSecrets
@@ -137,7 +129,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.1
-    - 7.0.0
     :when: 2022-08-16 18:11:21.184496539 Z
 - - :approve
   - Microsoft.Extensions.DependencyInjection
@@ -145,7 +136,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:21.651796135 Z
 - - :approve
   - Microsoft.Extensions.DependencyInjection.Abstractions
@@ -153,23 +143,20 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.Diagnostics.HealthChecks
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
     :versions:
-    - 6.0.10
-    - 7.0.3
+    - 6.0.15
     :when: 2022-08-29 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
     :versions:
-    - 6.0.10
-    - 7.0.3
+    - 6.0.15
     :when: 2022-08-29 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.FileProviders.Abstractions
@@ -177,7 +164,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:22.539614393 Z
 - - :approve
   - Microsoft.Extensions.FileProviders.Physical
@@ -185,7 +171,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:22.974981421 Z
 - - :approve
   - Microsoft.Extensions.FileSystemGlobbing
@@ -193,7 +178,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:23.404486462 Z
 - - :approve
   - Microsoft.Extensions.Hosting
@@ -201,7 +185,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.1
-    - 7.0.1
     :when: 2022-08-16 18:11:23.846859238 Z
 - - :approve
   - Microsoft.Extensions.Hosting.Abstractions
@@ -209,7 +192,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:24.291406794 Z
 - - :approve
   - Microsoft.Extensions.Logging
@@ -217,15 +199,13 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:24.728847267 Z
 - - :approve
   - Microsoft.Extensions.Logging.Abstractions
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
-    - 6.0.2
-    - 7.0.0
+    - 6.0.3
     :when: 2022-08-29 18:11:25.167886026 Z
 - - :approve
   - Microsoft.Extensions.Logging.Configuration
@@ -233,7 +213,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:25.603280883 Z
 - - :approve
   - Microsoft.Extensions.Logging.Console
@@ -241,7 +220,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:26.034503010 Z
 - - :approve
   - Microsoft.Extensions.Logging.Debug
@@ -249,7 +227,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:26.470514539 Z
 - - :approve
   - Microsoft.Extensions.Logging.EventLog
@@ -257,7 +234,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:26.934107393 Z
 - - :approve
   - Microsoft.Extensions.Logging.EventSource
@@ -265,7 +241,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:27.392784561 Z
 - - :approve
   - Microsoft.Extensions.Options
@@ -273,7 +248,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.1
     :when: 2022-08-16 18:11:27.836230472 Z
 - - :approve
   - Microsoft.Extensions.Options.ConfigurationExtensions
@@ -281,7 +255,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:28.266555006 Z
 - - :approve
   - Microsoft.Extensions.Primitives
@@ -289,14 +262,12 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:28.700166694 Z
 - - :approve
   - Microsoft.NET.Test.Sdk
   - :who: mocsharp
     :why: MIT (https://github.com/microsoft/vstest/raw/v17.4.0/LICENSE)
     :versions:
-    - 17.4.0
     - 17.5.0
     :when: 2022-08-16 18:11:29.155295778 Z
 - - :approve
@@ -449,7 +420,6 @@
     :why: MICROSOFT .NET LIBRARY License ( http://go.microsoft.com/fwlink/?LinkId=329770)
     :versions:
     - 4.3.0
-    - 7.0.1
     :when: 2022-08-16 18:11:40.143801413 Z
 - - :approve
   - System.Diagnostics.DiagnosticSource
@@ -464,7 +434,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:11:41.018661434 Z
 - - :approve
   - System.Diagnostics.Tools
@@ -875,7 +844,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:12:05.599984798 Z
 - - :approve
   - System.Text.Json
@@ -883,7 +851,6 @@
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
     - 6.0.0
-    - 7.0.0
     :when: 2022-08-16 18:12:06.051546721 Z
 - - :approve
   - System.Text.RegularExpressions

--- a/src/Plugins/AWSS3/Monai.Deploy.Storage.AWSS3.csproj
+++ b/src/Plugins/AWSS3/Monai.Deploy.Storage.AWSS3.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,10 +49,10 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.27" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.24" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.28" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.26" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Plugins/MinIO/Monai.Deploy.Storage.MinIO.csproj
+++ b/src/Plugins/MinIO/Monai.Deploy.Storage.MinIO.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,9 +48,9 @@
   
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.24" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.26" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Minio" Version="4.0.7" />
   </ItemGroup>
 

--- a/src/Plugins/MinIO/Tests/Monai.Deploy.Storage.MinIO.Tests.csproj
+++ b/src/Plugins/MinIO/Tests/Monai.Deploy.Storage.MinIO.Tests.csproj
@@ -27,10 +27,10 @@
   <ItemGroup>
     <PackageReference Include="Dangl.Xunit.Extensions.Ordering" Version="2.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Storage/Monai.Deploy.Storage.csproj
+++ b/src/Storage/Monai.Deploy.Storage.csproj
@@ -62,11 +62,11 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.24" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.26" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Storage/Tests/Monai.Deploy.Storage.Tests.csproj
+++ b/src/Storage/Tests/Monai.Deploy.Storage.Tests.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Description

- Remove use of .NET 7 nuget packages.
- Use 17.2.x of `System.IO.Abstractions`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
